### PR TITLE
Remove RADAR_RDBR layer, add RADAR_COVERAGE_RSNO[.INV], add version

### DIFF
--- a/deploy/default/geomet-mapproxy-cache-config.yml
+++ b/deploy/default/geomet-mapproxy-cache-config.yml
@@ -3,15 +3,16 @@ wms-server:
     url: ${GEOMET_MAPPROXY_CACHE_WMS}
     layers: [
         RADAR_1KM_RRAI,
-        RADAR_1KM_RDBR,
         RADAR_1KM_RSNO,
         RADAR_COVERAGE_RRAI,
+        RADAR_COVERAGE_RRAI.INV,
+        RADAR_COVERAGE_RSNO,
+        RADAR_COVERAGE_RSNO.INV,
         GDPS.ETA_TT,
         GDPS.ETA_UU,
         GDPS.ETA_NT,
         HRDPS.CONTINENTAL_TT,
         HRDPS.CONTINENTAL_HR,
-        RADAR_COVERAGE_RRAI.INV,
         HRDPS.CONTINENTAL_TD,
         GDPS.ETA_RT,
         HRDPS.CONTINENTAL_NT,

--- a/geomet_mapproxy/config.py
+++ b/geomet_mapproxy/config.py
@@ -189,7 +189,8 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
             'type': 'wms',
             'wms_opts': {
                 'featureinfo_format': 'application/vnd.ogc.gml',
-                'legendgraphic': True
+                'legendgraphic': True,
+                'version': '1.3.0'
             }
         }
 


### PR DESCRIPTION
- RDBR layer was deprecated
- Included RADAR_COVERAGE_RSNO and RADAR_COVERAGE_RSNO.INV in cache config
- Added WMS version 1.3.0 to all sources in config, without this MapProxy would default to making a WMS 1.1.1 request when an image was not found in the cache