### PR TITLE
Improve custom user agent handling

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -38,8 +38,6 @@ export GEOMET_MAPPROXY_TMP=/tmp
 export GEOMET_MAPPROXY_CONFIG=/opt/geomet-mapproxy/conf/geomet-mapproxy-config.yml
 export GEOMET_MAPPROXY_CACHE_CONFIG=/opt/geomet-mapproxy/conf/geomet-mapproxy-cache-config.yml
 
-export MAPPROXY_CLIENT_USER_AGENT=geomet-mapproxy
-
 if [ -d $GEOMET_MAPPROXY_CACHE_DATA ]
 then
     echo "Directory $GEOMET_MAPPROXY_CACHE_DATA exists"

--- a/deploy/default/geomet-mapproxy.wsgi
+++ b/deploy/default/geomet-mapproxy.wsgi
@@ -48,6 +48,4 @@ from mapproxy.wsgiapp import make_wsgi_app
 
 GEOMET_MAPPROXY_CONFIG = '/opt/geomet-mapproxy/geomet-mapproxy-config.yml'
 
-os.environ['MAPPROXY_CLIENT_USER_AGENT'] = 'geomet-mapproxy'
-
 application = make_wsgi_app(GEOMET_MAPPROXY_CONFIG, reloader=True)

--- a/deploy/nightly/geomet-mapproxy.wsgi
+++ b/deploy/nightly/geomet-mapproxy.wsgi
@@ -52,6 +52,4 @@ GEOMET_MAPPROXY_CONFIG = '/data/web/geomet-mapproxy-nightly/geomet-mapproxy-conf
 
 sys.path.insert(0, '/data/web/geomet-mapproxy-nightly/latest/lib/python3.6/site-packages')  # noqa
 
-os.environ['MAPPROXY_CLIENT_USER_AGENT'] = 'geomet-mapproxy'
-
 application = make_wsgi_app(GEOMET_MAPPROXY_CONFIG, reloader=True)

--- a/geomet_mapproxy/config.py
+++ b/geomet_mapproxy/config.py
@@ -27,12 +27,15 @@ from owslib.wms import WebMapService
 import yaml
 
 from geomet_mapproxy import cli_options
-from geomet_mapproxy.env import (GEOMET_MAPPROXY_CACHE_CONFIG,
-                                 GEOMET_MAPPROXY_CACHE_DATA,
-                                 GEOMET_MAPPROXY_CACHE_MAPFILE,
-                                 GEOMET_MAPPROXY_CACHE_XML,
-                                 GEOMET_MAPPROXY_CACHE_WMS,
-                                 GEOMET_MAPPROXY_CONFIG, GEOMET_MAPPROXY_TMP)
+from geomet_mapproxy.env import (
+    GEOMET_MAPPROXY_CACHE_CONFIG,
+    GEOMET_MAPPROXY_CACHE_DATA,
+    GEOMET_MAPPROXY_CACHE_MAPFILE,
+    GEOMET_MAPPROXY_CACHE_XML,
+    GEOMET_MAPPROXY_CACHE_WMS,
+    GEOMET_MAPPROXY_CONFIG,
+    GEOMET_MAPPROXY_TMP
+)
 from geomet_mapproxy.util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
@@ -97,24 +100,27 @@ def from_mapfile(layers):
     for layer in layers:
         if not all_layers:
             filepath = '{}/geomet-{}-en.map'.format(
-                os.path.dirname(GEOMET_MAPPROXY_CACHE_MAPFILE), layer)
+                os.path.dirname(GEOMET_MAPPROXY_CACHE_MAPFILE), layer
+            )
             LOGGER.debug('Reading layer mapfile from disk')
             f = mappyfile.open(filepath)
 
         if layer not in ltu.keys():
             ltu[layer] = {}
 
-        if ('wms_timeextent' in f['layers'][0]['metadata'].keys()):
+        if 'wms_timeextent' in f['layers'][0]['metadata'].keys():
             ltu[layer]['time'] = {
                 'default': f['layers'][0]['metadata']['wms_timedefault'],
                 'values': [f['layers'][0]['metadata']['wms_timeextent']]
             }
-        if ('wms_reference_time_default' in f['layers'][0]['metadata'].keys()):
+        if 'wms_reference_time_default' in f['layers'][0]['metadata'].keys():
             ltu[layer]['reference_time'] = {
-                'default':
-                    f['layers'][0]['metadata']['wms_reference_time_default'],
-                'values':
-                    [f['layers'][0]['metadata']['wms_reference_time_extent']]
+                'default': f['layers'][0]['metadata'][
+                    'wms_reference_time_default'
+                ],
+                'values': [
+                    f['layers'][0]['metadata']['wms_reference_time_extent']
+                ]
             }
     return ltu
 
@@ -195,33 +201,26 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
         }
 
         if 'RADAR' in layer:
-            layers.append({
-                'name': layer,
-                'title': layer,
-                'sources': ['{}_cache'.format(layer)],
-                'dimensions': {
-                    'time': {
-                        'default': None,
-                        'values': []
-                    }
+            layers.append(
+                {
+                    'name': layer,
+                    'title': layer,
+                    'sources': ['{}_cache'.format(layer)],
+                    'dimensions': {'time': {'default': None, 'values': []}}
                 }
-            })
+            )
         else:
-            layers.append({
-                'name': layer,
-                'title': layer,
-                'sources': ['{}_cache'.format(layer)],
-                'dimensions': {
-                    'time': {
-                        'default': None,
-                        'values': []
-                    },
-                    'reference_time': {
-                        'default': None,
-                        'values': []
+            layers.append(
+                {
+                    'name': layer,
+                    'title': layer,
+                    'sources': ['{}_cache'.format(layer)],
+                    'dimensions': {
+                        'time': {'default': None, 'values': []},
+                        'reference_time': {'default': None, 'values': []}
                     }
                 }
-            })
+            )
 
     dict_ = {
         'sources': sources,
@@ -243,15 +242,12 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
         'services': {
             'demo': None,
             'wms': {
-                'md': {
-                    'title': c['wms-server']['name']
-                },
+                'md': {'title': c['wms-server']['name']},
                 'versions': ['1.3.0', '1.1.1']
             }
         }
     }
-    final_dict = update_mapproxy_config(
-        dict_, c['wms-server']['layers'], mode)
+    final_dict = update_mapproxy_config(dict_, c['wms-server']['layers'], mode)
 
     return final_dict
 
@@ -279,9 +275,11 @@ def update_mapproxy_config(mapproxy_config, layers=[], mode='wms'):
         if layer_name in layers_to_update:
             for dim in layers_to_update[layer_name].keys():
                 layer['dimensions'][dim]['default'] = (
-                    layers_to_update[layer_name][dim]['default'])
+                    layers_to_update[layer_name][dim]['default']
+                )
                 layer['dimensions'][dim]['values'] = (
-                    layers_to_update[layer_name][dim]['values'])
+                    layers_to_update[layer_name][dim]['values']
+                )
 
     return mapproxy_config
 
@@ -300,8 +298,11 @@ def create(ctx, mode='wms'):
 
     click.echo('Creating {}'.format(TMP_FILE))
 
-    click.echo('Reading from initial layer list ({})'.format(
-       GEOMET_MAPPROXY_CACHE_CONFIG))
+    click.echo(
+        'Reading from initial layer list ({})'.format(
+            GEOMET_MAPPROXY_CACHE_CONFIG
+        )
+    )
 
     with open(GEOMET_MAPPROXY_CACHE_CONFIG) as fh:
         mapproxy_cache_config = yaml_load(fh)

--- a/geomet_mapproxy/config.py
+++ b/geomet_mapproxy/config.py
@@ -230,6 +230,14 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
         'globals': {
             'cache': {
                 'base_dir': GEOMET_MAPPROXY_CACHE_DATA,
+            },
+            'http': {
+                'headers': {
+                    'User-agent': (
+                        'geomet-mapproxy '
+                        '(https://github.com/ECCC-MSC/geomet-mapproxy)'
+                    )
+                }
             }
         },
         'services': {


### PR DESCRIPTION
This MR moves the setting of the custom MapProxy user agent into the MapProxy configuration itself without having to rely on environment variables and the need to modify the MapProxy source code (see https://github.com/mapproxy/mapproxy/compare/master...ECCC-MSC:mapproxy:user-agent).

Instead the user agent is modified via the configuration itself which now includes a `globals.http.headers` key which sets the `User-agent` HTTP header, overriding the one set via MapProxy's `HTTPClient` object.

Tested by pointing the MapProxy configuration to my development build of GeoMet-Weather and logging the headers via the WSGI application's `environ` dictionnary when receiving requests made by the MapProxy instance.

```
➜ geomet2-runserver
Serving on port 8020...
User agent is: geomet-mapproxy-0.1.0
xxx.xxx.xxx.xxx - - [10/May/2023 17:00:24] "GET /?layers=RADAR_1KM_RRAI&transparent=True&format=image%2Fpng&bbox=10.37109375,-79.62890625,23.37890625,-66.62109375&width=1184&height=1184&time=2023-05-10T12%3A54%3A00Z&request=GetMap&version=1.3.0&service=WMS&styles=&crs=EPSG%3A4326 HTTP/1.1" 200 7970
```

