### PR TITLE
add EPSG:3978 and EPSG:3857 grids

### DIFF
--- a/geomet_mapproxy/config.py
+++ b/geomet_mapproxy/config.py
@@ -187,7 +187,11 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
         LOGGER.debug('Configuring layer: {}'.format(layer))
         LOGGER.debug('Configuring layer caches')
         caches['{}_cache'.format(layer)] = {
-            'grids': ['GLOBAL_GEODETIC'],
+            'grids': [
+                'GLOBAL_GEODETIC',
+                'GLOBAL_WEBMERCATOR',
+                'CANADA_ATLAS_LAMBERT'
+            ],
             'sources': ['{}_source'.format(layer)]
         }
 
@@ -230,6 +234,12 @@ def create_initial_mapproxy_config(mapproxy_cache_config, mode='wms'):
                         '(https://github.com/ECCC-MSC/geomet-mapproxy)'
                     )
                 }
+            },
+        },
+        'grids': {
+            'CANADA_ATLAS_LAMBERT': {
+                'srs': 'EPSG:3978',
+                'bbox': [-7192737.96, -3004297.73, 5183275.29, 4484204.83]
             }
         },
         'services': {


### PR DESCRIPTION
This PR adds the EPSG:3857 and EPSG:3978 grids to the config file produced by geomet-maproxy.