### PR TITLE
update nightly Docker build URLs to dev-22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@
 
 FROM ubuntu:focal
 
-ARG GEOMET_MAPPROXY_URL=https://geomet-dev-21-nightly.cmc.ec.gc.ca/geomet-mapproxy
+ARG GEOMET_MAPPROXY_URL=https://geomet-dev-22-nightly.cmc.ec.gc.ca/geomet-mapproxy
 
 ENV BASEDIR=/data/web/geomet-mapproxy-nightly
 ENV DOCKERDIR=${BASEDIR}/docker \
@@ -38,7 +38,7 @@ ENV DOCKERDIR=${BASEDIR}/docker \
     GEOMET_MAPPROXY_LOGGING_LOGLEVEL=DEBUG \
     GEOMET_MAPPROXY_LOGGING_LOGFILE=/tmp/geomet-mapproxy-nightly.log \
     GEOMET_MAPPROXY_CACHE_DATA=$BASEDIR/cache_data \
-    GEOMET_MAPPROXY_CACHE_WMS=https://geomet-dev-21-nightly.cmc.ec.gc.ca/geomet \
+    GEOMET_MAPPROXY_CACHE_WMS=https://geomet-dev-22-nightly.cmc.ec.gc.ca/geomet \
     GEOMET_MAPPROXY_CACHE_MAPFILE=/opt/geomet/conf/geomet-en.map \
     GEOMET_MAPPROXY_CACHE_XML=/opt/geomet/conf/geomet-wms-1.3.0-capabilities-en.xml \
     GEOMET_MAPPROXY_URL=$GEOMET_MAPPROXY_URL \

--- a/deploy/nightly/deploy-nightly-docker.sh
+++ b/deploy/nightly/deploy-nightly-docker.sh
@@ -31,7 +31,7 @@
 BASEDIR=/data/web/geomet-mapproxy-nightly
 GEOMET_MAPPROXY_GITREPO=https://github.com/ECCC-MSC/geomet-mapproxy.git
 DAYSTOKEEP=7
-GEOMET_MAPPROXY_URL=https://geomet-dev-21-nightly.cmc.ec.gc.ca/geomet-mapproxy
+GEOMET_MAPPROXY_URL=https://geomet-dev-22-nightly.cmc.ec.gc.ca/geomet-mapproxy
 
 DATETIME=`date +%Y%m%d`
 TIMESTAMP=`date +%Y%m%d.%H%M`

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.ym
 
 # test OGC WMS endpoint
 ```bash
-curl "http://geomet-dev-21.cmc.ec.gc.ca:5091/service?request=GetCapabilities"
+curl "http://geomet-dev-22.cmc.ec.gc.ca:5091/service?request=GetCapabilities"
 # or
-curl "https://geomet-dev-21-nightly.cmc.ec.gc.ca/geomet-mapproxy/service?request=GetCapabilities"
+curl "https://geomet-dev-22-nightly.cmc.ec.gc.ca/geomet-mapproxy/service?request=GetCapabilities"
 ```

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -2,6 +2,6 @@ services:
   geomet-mapproxy:
     build:
       args:
-        GEOMET_MAPPROXY_URL: https://geomet-dev-21-nightly.cmc.ec.gc.ca/geomet-mapproxy
+        GEOMET_MAPPROXY_URL: https://geomet-dev-22-nightly.cmc.ec.gc.ca/geomet-mapproxy
     ports:
       - "5091:80"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: unless-stopped
     build:
         context: ..
-    hostname: geomet-dev-21-docker.cmc.ec.gc.ca
+    hostname: geomet-dev-22-docker.cmc.ec.gc.ca
     volumes:
         - "/tmp:/tmp:rw"
 networks:


### PR DESCRIPTION
This PR updates all Docker nightly build URLs to `geomet-dev-22`.