### PR TITLE
avoid overwriting default time dimension when updating config

### DIFF
--- a/geomet_mapproxy/config.py
+++ b/geomet_mapproxy/config.py
@@ -282,8 +282,6 @@ def update_mapproxy_config(mapproxy_config, layers=[], mode='wms'):
                     layer['dimensions'] = {}
                 layer['dimensions'][dim] = {
                     'default': layers_to_update[layer_name][dim]['default'],
-                }
-                layer['dimensions'][dim] = {
                     'values': layers_to_update[layer_name][dim]['values']
                 }
 


### PR DESCRIPTION
This PR ensures that that both the `default` and `values` keys are retained within a given layer's dimension key when updating the  MapProxy configuration via `geomet-mapproxy`.