### PR TITLE
add request headers required by MapProxy to nightly's Apache config

### DIFF
--- a/deploy/nightly/deploy-nightly-docker.sh
+++ b/deploy/nightly/deploy-nightly-docker.sh
@@ -68,6 +68,8 @@ cat > geomet-mapproxy-nightly.conf <<EOF
   ProxyPassReverse http://localhost:5091
   Header set Access-Control-Allow-Origin "*"
   Header set Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  RequestHeader set X-Script-Name "/geomet-mapproxy"
+  RequestHeader set X-Forwarded-Proto https
   Require all granted
 </Location>
 EOF


### PR DESCRIPTION
This PR adds the appropriate request headers to the GeoMet-MapProxy nightly Apache config. These request headers are then used by MapProxy to generate valid URLs in its GetCapabilities response.