### PR TITLE
Add REQUESTS_CA_BUNDLE to postinst

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -38,5 +38,6 @@ if [ -d $GEOMET_MAPPROXY_CONFIG ]
 then
     echo "Configuration $GEOMET_MAPPROXY_CONFIG exists"
 else
+    export REQUESTS_CA_BUNDLE=/etc/ssl/certs/
     geomet-mapproxy config create
 fi


### PR DESCRIPTION
Fix for python attempting to connect to services where there are user-installed TLS certificates on the host machine rather than using the pip3 python-requests/python-certifi embedded cert bundles (which cannot be user-modified like the system ones).