### PR TITLE
Docker nightly fixes for geomet-dev-32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@
 # =================================================================
 
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ARG GEOMET_MAPPROXY_URL=https://geomet-dev-32-nightly.edc-mtl.ec.gc.ca/geomet-mapproxy
 
@@ -48,10 +48,13 @@ ENV DOCKERDIR=${BASEDIR}/docker \
     GUNICORN_GEOMET_MAPPROXY_ACCESSLOG=/tmp/gunicorn-geomet-mapproxy-nightly-access.log \
     GUNICORN_GEOMET_MAPPROXY_ERRORLOG=/tmp/gunicorn-geomet-mapproxy-nightly-errors.log
 
+# ignore debian install prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
 # install system dependencies
 RUN sed -i 's#http://archive.ubuntu.com/ubuntu/#mirror://mirrors.ubuntu.com/mirrors.txt#g' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y software-properties-common && \
-    add-apt-repository ppa:gcpp-kalxas/wmo && add-apt-repository ppa:ubuntugis/ubuntugis-unstable && apt update && \
+    add-apt-repository -y ppa:gcpp-kalxas/wmo && add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable && apt update && \
     apt-get install -y python3 python3-pip python3-pil python3-yaml python3-pyproj && \
     # ## other misc dependencies
     apt install -y git cron make && \
@@ -66,7 +69,7 @@ RUN pip3 install -r requirements.txt && \
     # add gunicorn for Docker deploy
     pip3 install gunicorn && \
     # install geomet-mapproxy
-    pip install . && \
+    pip3 install . && \
     # Set up cache data directory
     mkdir -p $GEOMET_MAPPROXY_CACHE_DATA && \
     # Amend permissions to crontab and use crontab command to make file known to the cron daemon

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     build:
       context: ..
+    environment:
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
     hostname: geomet-dev-32-docker.edc-mtl.ec.gc.ca
     volumes:
       - "/tmp:/tmp:rw"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,6 +38,8 @@ CONTAINER_HOST=${CONTAINER_HOST:=0.0.0.0}
 CONTAINER_PORT=${CONTAINER_PORT:=80}
 WSGI_WORKERS=${WSGI_WORKERS:=2}
 WSGI_WORKER_TIMEOUT=${WSGI_WORKER_TIMEOUT:=900}
+GEOMET_MAPPROXY_CONFIG=${GEOMET_MAPPROXY_CONFIG}
+REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE}
 
 # create default cache directory
 echo "Creating default cache directory for geomet-mapproxy"
@@ -47,20 +49,29 @@ geomet-mapproxy cache create
 echo "Creating initial config for geomet-mapproxy"
 geomet-mapproxy config create
 
+# Stop if config was not created
+if [ ! -f "$GEOMET_MAPPROXY_CONFIG" ]; then
+    echo "ERROR: Config file was not created. Exiting."
+    exit 1
+fi
+
 # pass in GEOMET_MAPPROXY env variables to /etc/environment so they are available to cron
 env | grep ^GEOMET_MAPPROXY >> /etc/environment
+printenv | grep 'REQUESTS_CA_BUNDLE' >> /etc/environment
 # startup cron jobs (builds mapfile at schedule cron settings)
 service cron start
 
 # startup geomet-mapproxy on gunicorn
 echo "Starting gunicorn for name=${CONTAINER_NAME} on ${CONTAINER_HOST}:${CONTAINER_PORT} with ${WSGI_WORKERS} workers. Access logs output to ${GUNICORN_GEOMET_MAPPROXY_ACCESSLOG} and error logs to ${GUNICORN_GEOMET_MAPPROXY_ERRORLOG}"
-gunicorn --workers ${WSGI_WORKERS} \
+gunicorn \
+    --workers ${WSGI_WORKERS} \
     --name=${CONTAINER_NAME} \
     --bind ${CONTAINER_HOST}:${CONTAINER_PORT} \
-    --chdir $BASEDIR/geomet_mapproxy wsgi:application \
+    --chdir $BASEDIR/geomet_mapproxy \
     --reload \
     --timeout ${WSGI_WORKER_TIMEOUT} \
     --access-logfile $GUNICORN_GEOMET_MAPPROXY_ACCESSLOG \
-    --error-logfile $GUNICORN_GEOMET_MAPPROXY_ERRORLOG
+    --error-logfile $GUNICORN_GEOMET_MAPPROXY_ERRORLOG \
+    wsgi:application   # should always be the last argument
 
 echo "END /entrypoint.sh"


### PR DESCRIPTION
- use ubuntu:jammy
- ensure to use pip3 for consistency
- small additions in Dockerfile to prevent debian interactive prompts
- ensure REQUESTS_CA_BUNDLE is properly set to prevent SSL request errors
- fix to gunicorn arguments order in entrypoint.sh
- added fail safe check for geomet-mapproxy config create